### PR TITLE
Fix 5.5 errors and warnings caused by GetSubsystemArray

### DIFF
--- a/Source/Runtime/Private/ExtendableGameStateBase.cpp
+++ b/Source/Runtime/Private/ExtendableGameStateBase.cpp
@@ -28,19 +28,19 @@ void AExtendableGameStateBase::BeginPlay()
 {
 	Super::BeginPlay();
 
-	for(UGameStateSubsystem* Subsystem : GetSubsystemArray<UGameStateSubsystem>())
+	SubsystemCollection.ForEachSubsystem([this](UGameStateSubsystem* Subsystem)
 	{
 		AddReplicatedSubObject(Subsystem);
 		Subsystem->BeginPlay();
-	}
+	}, UGameStateSubsystem::StaticClass());
 }
 
 void AExtendableGameStateBase::EndPlay(const EEndPlayReason::Type EndPlayReason)
 {
-	for(UGameStateSubsystem* Subsystem : GetSubsystemArray<UGameStateSubsystem>())
+	SubsystemCollection.ForEachSubsystem([this](UGameStateSubsystem* Subsystem)
 	{
 		RemoveReplicatedSubObject(Subsystem);
-	}
+	}, UGameStateSubsystem::StaticClass());
 	
 	SubsystemCollection.Deinitialize();
 	

--- a/Source/Runtime/Public/ExtendableGameStateBase.h
+++ b/Source/Runtime/Public/ExtendableGameStateBase.h
@@ -57,17 +57,6 @@ public:
 		return nullptr;
 	}
 
-	/**
-	 * Get all Subsystem of specified type, this is only necessary for interfaces that can have multiple implementations instanced at a time.
-	 *
-	 * Do not hold onto this Array reference unless you are sure the lifetime is less than that of AExtendableGameStateBase
-	 */
-	template <typename TSubsystemClass>
-	const TArray<TSubsystemClass*>& GetSubsystemArray() const
-	{
-		return SubsystemCollection.GetSubsystemArray<TSubsystemClass>(TSubsystemClass::StaticClass());
-	}
-
 private:
 
 	FObjectSubsystemCollection<UGameStateSubsystem> SubsystemCollection;


### PR DESCRIPTION
Replaced `GetSubsystemArray` access with `SubsystemCollection.ForEachSubsystem()` iteration in the BeginPlay and EndPlay triggers in ExtendableGameStateBase to address 5.5 depreciation warnings and errors.

GetSubsystemArrayCopy (understandably) returns a temporary/local address so the other option is to iterate directly. The function in the game state didn't seem to be used elsewhere and SubsystemCollection is accessible to the game state itself anyway, whereas for other classes I'm not sure how meaningful it is for it to be accessible.

Fixes #3 